### PR TITLE
override default page size

### DIFF
--- a/kiwiki/kiwiki.py
+++ b/kiwiki/kiwiki.py
@@ -73,7 +73,7 @@ class KiwiClient:
         self._with_valid_session()
         sensor_list = requests.get(
             API_LIST_DOOR_URL,
-            params={"session_key": self.__session_key},
+            params={"session_key": self.__session_key, "page_size": 999},
             headers={"Accept": "application/json"},
             timeout=self.__timeout
         )


### PR DESCRIPTION
The KIWI API only returns 20 sensors if not given a different page size.
There's no option to return all sensors at the same time.
Passing a suffiently high number to the API call ensures that all the locks are returned.
This fixes problems downstream, where not all locks are visible if a user has many locks in his account to choose from.